### PR TITLE
Replace swaylock-blur with swaylock-effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
 
 * [swayidle](https://github.com/swaywm/swayidle) - Idle management daemon for Wayland
 * [swaylock](https://github.com/swaywm/swaylock) - Screen locker for Wayland
-* [swaylock-blur](https://github.com/cjbassi/swaylock-blur) - A small Rust program that runs swaylock and sets the image to a blurred screenshot of the desktop
+* [swaylock-effects](https://github.com/mortie/swaylock-effects) - A fork of swaylock with effects such as a blurred screenshot as background or a clock on the lockscreen
 * [waylock](https://github.com/ifreund/waylock) - A simple screenlocker for Wayland compositors
 
 ## Screencasting


### PR DESCRIPTION
swaylock-blur is deprecated in favor of swaylock-effects, see https://github.com/cjbassi/swaylock-blur/blob/master/README.md