### PR TITLE
update yambar link

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
 * [i3status-rust](https://github.com/greshake/i3status-rust) - Very resource-friendly and feature-rich replacement for i3status, written in pure Rust
 * [rootbar](https://hg.sr.ht/~scoopta/rootbar) - Root Bar is a bar for wlroots based Wayland compositors such as sway
 * [waybar](https://github.com/Alexays/Waybar) - Highly customizable Wayland bar for Sway and Wlroots based compositors
-* [yambar](https://gitlab.com/dnkl/yambar) - Modular status panel for X11 and Wayland, inspired by polybar
+* [yambar](https://codeberg.org/dnkl/yambar) - Modular status panel for X11 and Wayland, inspired by polybar
 
 ## Tools
 


### PR DESCRIPTION
yambar's development has moved to Codeberg and its original repository on GitLab is now just a mirror.