### PR TITLE
Added firefox to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
     * [Viper Browser](https://github.com/LeFroid/Viper-Browser) - A lightweight browser using QtWebEngine
 
 * WebKit2GTK
+    * [Firefox](https://www.mozilla.org/en-US/firefox/new/?redirect_source=firefox-com) - Firefox now supports wayland
     * [Surfer](https://github.com/nihilowy/surfer) - Simple keyboard based webkit2gtk browser
     * [wyeb](https://github.com/jun7/wyeb) - A vim-like webkit2gtk browser
 


### PR DESCRIPTION
Firefox now supports wayland, with a package ready to download in Fedoras package manager, and can be compiled from scratch for other distros (like arch, debian, etc.)