### PR TITLE
Add lswt and wlopm

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
 
 ## Tools
 
+* [lswt](https://git.sr.ht/~leon_plickat/lswt) - List Wayland toplevels in both human readable and machine parsable formats
 * [wtype](https://github.com/atx/wtype) - A Wayland tool that allows you to simulate keyboard input like [xdotool](https://github.com/jordansissel/xdotool)
 * [ydotool](https://github.com/ReimuNotMoe/ydotool) - A generic Linux command-line automation tool for Wayland
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
 * [Wallutils](https://github.com/xyproto/wallutils) - A set of utilities to manage monitors, resolutions, wallpapers and timed wallpapers
 * [wdisplays](https://github.com/cyclopsian/wdisplays) - GUI display configurator for wlroots compositors
 * [wlay](https://github.com/atx/wlay) - Graphical output management for Wayland
+* [wlopm](https://git.sr.ht/~leon_plickat/wlopm) - Wayland output power management tool
 * [wlr-randr](https://github.com/emersion/wlr-randr) - An xrandr clone for wlroots compositors
 
 ## Email Clients


### PR DESCRIPTION
This adds two new tools I recently created, `lswt` and `wlopm`, which are useful for compositors that implement the `zwlr-output-power-management-unstable-v1` and `wlr-foreign-toplevel-management-unstable-v1` protocol extensions.