### PR TITLE
Update `labwc` (Lab Wayland Compositor) link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
 * [hikari](https://hikari.acmelabs.space/) - A hybrid stacking/tiling Wayland compositor
 * [japokwm](https://github.com/werererer/japokwm) - A wlroots based dynamic tiling wayland compositor based around creating layouts
 * [KWin](https://invent.kde.org/plasma/kwin) - KDE window manager and compositor
-* [labwc](https://github.com/johanmalm/labwc) - A stacking Wayland compositor with look and feel of openbox
+* [labwc](https://github.com/labwc/labwc) - A stacking Wayland compositor with look and feel of openbox
 * [Mutter](https://wiki.gnome.org/Projects/Mutter/) - A window and compositing manager that displays and manages your desktop via OpenGL
 * [newm](https://github.com/jbuchermn/newm) - A Wayland compositor written with laptops and touchpads in mind
 * [river](https://github.com/ifreund/river) - A dynamic tiling Wayland compositor


### PR DESCRIPTION
```
Now moved to GitHub-based organization.
```