### PR TITLE
Add Librewolf as a firefox based web browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
 ## Browsers without X library dependency
 * Firefox and forks
     * [Firefox](https://www.mozilla.org/en-US/firefox/new/) - For using Firefox on wayland just add `MOZ_ENABLE_WAYLAND=1` to your environment variables
+    * [Librewolf](https://librewolf.net/) - An independent fork of Firefox, with the primary goals of privacy, security and user freedom
     * [Tor Browser](https://www.torproject.org/download/) - Tor Browser Bundle: anonymous browsing using Firefox and Tor 
 
 * QtWebEngine


### PR DESCRIPTION
Librewolf is a fork of Firefox, it is for users who don't want to sacrifice Internet speed using tor, but still want privacy and freedom. Below is the introduction taken from https://librewolf.net/


>This project is an independent fork of Firefox, with the primary goals of privacy, security and user freedom.
>
>LibreWolf is designed to increase protection against tracking and fingerprinting techniques, while also including a few security improvements. This is achieved through our privacy and security oriented settings and patches. LibreWolf also aims to remove all the telemetry, data collection and annoyances, as well as disabling anti-freedom features like DRM.
