### PR TITLE
Add Xfce Terminal to terminal emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
 * [Termite](https://github.com/thestinger/termite) - A keyboard-centric VTE-based terminal, aimed at use within a window manager with tiling and/or tabbing support (Termite is obsoleted by Alacritty!)
 * [wezterm](https://wezfurlong.org/wezterm/) - A GPU-accelerated cross-platform terminal emulator and multiplexer
 * [wterm](https://github.com/majestrate/wterm) - An [st](https://st.suckless.org/) fork for wayland
+* [Xfce Terminal](https://docs.xfce.org/apps/terminal/start) - A graphically-configurable terminal for Xfce
 
 ## Text Editors
 


### PR DESCRIPTION
Xfce Terminal works flawlessly on Wayland sessions. It's also easy to configure graphically despite offering dozens of different options.