### PR TITLE
Added tofi (dmenu replacement) to launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
 * [Wofi](https://hg.sr.ht/~scoopta/wofi) - A launcher/menu program for wlroots based Wayland compositors such as sway
 * [yofi](https://github.com/l4l/yofi) - A minimalistic menu for wayland
 * [rofi](https://github.com/lbonn/rofi) - A fork of rofi with Wayland support
+* [tofi](https://github.com/philj56/tofi) - Tiny dynamic menu for Wayland
 
 ## Libraries
 


### PR DESCRIPTION
To quote its readme:

> [Tofi](https://github.com/philj56/tofi) is an extremely fast and simple [dmenu](https://tools.suckless.org/dmenu/) / [rofi](https://github.com/davatorium/rofi) replacement for [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots)-based [Wayland](https://wayland.freedesktop.org/) compositors such as [Sway](https://github.com/swaywm/sway/).
