### PR TITLE
remove oguri from wallpaper category

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ No Wayland-specific requirements, so you can use your xorg solution of choice to
 
 ## Wallpaper
 
-* [oguri](https://github.com/vilhalmer/oguri) - A very nice animated wallpaper daemon for Wayland compositors
 * [mpvpaper](https://github.com/GhostNaN/mpvpaper) - A video wallpaper program for wlroots based wayland compositors
 * [plasma-apply-wallpaperimage](https://invent.kde.org/plasma/plasma-workspace) - A terminal utility to change wallpaper on Plasma
 * [swaybg](https://github.com/swaywm/swaybg) - A wallpaper utility for Wayland compositors


### PR DESCRIPTION
oguri is unmaintained and archived.
https://github.com/vilhalmer/oguri
In the project readme swww is mentioned as a direct replacement and mpvpaper for those who want real video.